### PR TITLE
Fixed bug, when 'textFieldDidEndEditing' is never called on delegate …

### DIFF
--- a/UITextField+Blocks.m
+++ b/UITextField+Blocks.m
@@ -103,7 +103,7 @@ static const void *UITextFieldShouldReturnKey                       = &UITextFie
     id delegate = objc_getAssociatedObject(self, UITextFieldDelegateKey);
     
     if ([delegate respondsToSelector:@selector(textFieldDidEndEditing:)]) {
-        [delegate textFieldDidBeginEditing:textField];
+        [delegate textFieldDidEndEditing:textField];
     }
 }
 


### PR DESCRIPTION
…(typo?)
